### PR TITLE
Need MOSAIK attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ At the end of a simulation run, results are stored in the following two files:
  - `interactions.tsv`: first column also gives the iteration number, second column gives the total execution time for registered updates and the number of GET, PUT, DELETE, POST interactions with agents (included average processing time for each)
 
 Results for any two successive runs are separated by `\n\n` (Gnuplot convention for multi-dataset files). Each dataset, i.e. data for a single run, includes a header line starting with `#` (Gnuplot comment symbol).
+
+# Acknowledgments
+
+This work was partially funded by the German Federal Ministry of Education and Researchthrough the MOSAIK project (grant no. 01IS18070A).


### PR DESCRIPTION
We want to reference the BOLD server in a project report for MOSAIK and thus would need the standard attribution statement:
`This work was partially funded by the German Federal Ministry of Education and Researchthrough the MOSAIK project (grant no. 01IS18070A).`